### PR TITLE
feat: support importing YOLO .txt annotation files

### DIFF
--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { useAppStore } from '../store/useAppStore';
-import { downloadJSON, downloadYOLO, downloadBoth, importJSON } from '../lib/export';
+import { downloadJSON, downloadYOLO, downloadBoth, importJSON, importYOLO } from '../lib/export';
 import { clearSession } from '../lib/storage';
 import type { AnnotationSession } from '../lib/types';
 
@@ -16,6 +16,7 @@ export default function ExportPanel() {
   const imageWidth = useAppStore((s) => s.imageWidth);
   const imageHeight = useAppStore((s) => s.imageHeight);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const yoloFileInputRef = useRef<HTMLInputElement>(null);
 
   const hasAnnotations = annotationCount > 0;
   const hasImage = !!imageName;
@@ -55,6 +56,21 @@ export default function ExportPanel() {
       useAppStore.getState().restoreSession(session.annotations);
     } catch (err) {
       alert(`Failed to import JSON: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+
+    // Reset input so the same file can be re-imported
+    e.target.value = '';
+  };
+
+  const handleImportYOLO = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const annotations = await importYOLO(file, imageWidth, imageHeight);
+      useAppStore.getState().restoreSession(annotations);
+    } catch (err) {
+      alert(`Failed to import YOLO: ${err instanceof Error ? err.message : 'Unknown error'}`);
     }
 
     // Reset input so the same file can be re-imported
@@ -102,6 +118,21 @@ export default function ExportPanel() {
           type="file"
           accept=".json"
           onChange={handleImport}
+          className="hidden"
+        />
+        <button
+          onClick={() => yoloFileInputRef.current?.click()}
+          disabled={!hasImage}
+          className="w-full px-3 py-1.5 text-xs font-medium rounded bg-gray-50 text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          aria-label="Import annotations from YOLO text file"
+        >
+          Import YOLO
+        </button>
+        <input
+          ref={yoloFileInputRef}
+          type="file"
+          accept=".txt"
+          onChange={handleImportYOLO}
           className="hidden"
         />
       </div>

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -103,10 +103,24 @@ export function fromYOLO(text: string, imageWidth: number, imageHeight: number):
     }
 
     const nums = parts.map(Number);
-    if (nums.some((n) => Number.isNaN(n))) {
+    if (nums.some((n) => !Number.isFinite(n))) {
       throw new Error(`Invalid YOLO line (non-numeric field): "${line}"`);
     }
     const [rawClassId, cx, cy, nw, nh] = nums;
+    if (
+      !Number.isInteger(rawClassId) ||
+      rawClassId < 0 ||
+      cx < 0 ||
+      cx > 1 ||
+      cy < 0 ||
+      cy > 1 ||
+      nw <= 0 ||
+      nw > 1 ||
+      nh <= 0 ||
+      nh > 1
+    ) {
+      throw new Error(`Invalid YOLO line (out-of-range field): "${line}"`);
+    }
 
     const classId = rawClassId + 1; // YOLO 0-indexed -> app 1-indexed
     if (!CLASSES.some((c) => c.id === classId)) {

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -1,5 +1,6 @@
 import JSZip from 'jszip';
-import type { AnnotationSession } from './types';
+import type { Annotation, AnnotationSession } from './types';
+import { CLASSES } from './constants';
 
 export function toJSON(session: AnnotationSession): string {
   return JSON.stringify(session, null, 2);
@@ -86,4 +87,53 @@ export async function importJSON(file: File): Promise<AnnotationSession> {
   }
 
   return data as AnnotationSession;
+}
+
+export function fromYOLO(text: string, imageWidth: number, imageHeight: number): Annotation[] {
+  const lines = text
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  const annotations: Annotation[] = [];
+
+  for (const line of lines) {
+    const parts = line.split(/\s+/);
+    if (parts.length !== 5) {
+      throw new Error(`Invalid YOLO line: "${line}"`);
+    }
+
+    const nums = parts.map(Number);
+    if (nums.some((n) => Number.isNaN(n))) {
+      throw new Error(`Invalid YOLO line (non-numeric field): "${line}"`);
+    }
+    const [rawClassId, cx, cy, nw, nh] = nums;
+
+    const classId = rawClassId + 1; // YOLO 0-indexed -> app 1-indexed
+    if (!CLASSES.some((c) => c.id === classId)) {
+      throw new Error(`Unknown YOLO class id ${rawClassId} in line: "${line}"`);
+    }
+
+    const w = nw * imageWidth;
+    const h = nh * imageHeight;
+    const x = cx * imageWidth - w / 2;
+    const y = cy * imageHeight - h / 2;
+
+    annotations.push({
+      id: crypto.randomUUID(),
+      classId,
+      bbox: [x, y, w, h],
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  return annotations;
+}
+
+export async function importYOLO(
+  file: File,
+  imageWidth: number,
+  imageHeight: number,
+): Promise<Annotation[]> {
+  const text = await file.text();
+  return fromYOLO(text, imageWidth, imageHeight);
 }


### PR DESCRIPTION
## Summary

Adds support for importing YOLO `.txt` annotation files, so corrections can be made from a YOLO label file instead of requiring a full JSON session export.

- `fromYOLO(text, imageWidth, imageHeight)` in [`src/lib/export.ts`](src/lib/export.ts) parses YOLO-format lines (`classId cx cy w h`, normalized 0–1, 0-indexed class ids) into `Annotation[]`, converting class ids back to the app's 1-indexed scheme and denormalizing against the currently-loaded image's pixel dimensions.
- `importYOLO(file, imageWidth, imageHeight)` is the file-reading wrapper, mirroring `importJSON`'s validation style (throws a descriptive error on malformed lines or unknown class ids).
- `ExportPanel.tsx` gets a new "Import YOLO" button + hidden `.txt` file input next to the existing "Import JSON" control, wired to the existing `restoreSession` store action.

No store changes were needed — `restoreSession(annotations: Annotation[])` already accepts exactly what the new parser produces.

Closes #24

## Testing

- `npm run build` — type-checks and builds clean.
- `npm run lint` — clean.
- Manually verified in the browser: loaded a test image, drew a "text" and a "music" box, exported YOLO, then re-imported that exact YOLO file — both boxes came back with correct class and position (round-trip confirmed).
- Verified error handling: fed a malformed YOLO file (unknown class id, malformed line) through import — got a clear `alert(...)` and confirmed existing annotations were left untouched (no partial import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing YOLO annotation files in `.txt` format.
  - Imported annotations are converted to image regions and restored automatically.
  - Added an **Import YOLO** option to the export panel.
  - Displays an error when an imported file contains invalid annotation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->