### PR TITLE
ci: auto-deploy to gh-pages on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,17 +6,26 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: github-pages-deploy
+  cancel-in-progress: false
+
+# Read-only by default; only the deploy job below escalates to contents: write.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -27,7 +36,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist


### PR DESCRIPTION
## Problem
The deployed GitHub Pages site was frozen at whatever commit someone last ran `npm run deploy` against locally (2026-05-28). Since then `main` moved on by 61 commits, including merged PRs #12, #14, #20, #25 — none of which ever reached the live site.

Root cause: deployment was entirely manual (`gh-pages` npm package via `npm run deploy`). The only existing GitHub Actions workflow (`lint-format-typecheck.yml`) just lints/type-checks and explicitly ignores the `gh-pages` branch — nothing auto-deploys.

## Fix
Add `.github/workflows/deploy.yml`: builds the app and pushes `dist/` to `gh-pages` automatically on every push to `main` (plus a manual `workflow_dispatch` trigger), using `peaceiris/actions-gh-pages`. No repo Settings changes needed — Pages stays in its current "deploy from `gh-pages` branch" mode.

Merging this PR will itself trigger the first auto-deploy and catch the live site up to current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated deployment to GitHub Pages when changes are pushed to the main branch.
  * Added an option to trigger deployments manually.
  * Builds and publishes the latest project output automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->